### PR TITLE
Rename unique table lookup function to match implementation

### DIFF
--- a/progetto/include/unique_table.hpp
+++ b/progetto/include/unique_table.hpp
@@ -57,9 +57,9 @@ extern "C" {
 void unique_table_clear(void);
 
 /* lookup/insert (host‑only per ora – versione device in futuro) */
-OBDDNode* unique_get_or_create(int var,
-                               OBDDNode* low,
-                               OBDDNode* high);
+OBDDNode* unique_table_get_or_create(int var,
+                                     OBDDNode* low,
+                                     OBDDNode* high);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
## Summary
- Rename unique table lookup declaration to `unique_table_get_or_create` for consistency with its definition

## Testing
- `make -C progetto clean`
- `make -C progetto CUDA=0`


------
https://chatgpt.com/codex/tasks/task_e_689505939168832587edd4e80a57f94a