### PR TITLE
Fix unique table API name and thread cache macro

### DIFF
--- a/progetto/src/apply_cache.cpp
+++ b/progetto/src/apply_cache.cpp
@@ -25,7 +25,7 @@ struct KeyHash {
 };
 
 /* ---------- modalità GLOBAL vs THREAD_local --------------------*/
-#if defined(DOBDD_PER_THREAD_CACHE)
+#if defined(OBDD_PER_THREAD_CACHE)
 /* ---- 1) cache privata al thread --------------------------------*/
 static thread_local std::unordered_map<Key,OBDDNode*,KeyHash> tl_cache;
 
@@ -85,7 +85,7 @@ void apply_cache_global_merge() {}          /* no-op */
 /* helper per debug / test */
 void apply_cache_clear()
 {
-#if defined(DOBDD_PER_THREAD_CACHE)
+#if defined(OBDD_PER_THREAD_CACHE)
     tl_cache.clear();
 #else
     std::lock_guard<std::mutex> g(mtx);

--- a/progetto/src/unique_table.cpp
+++ b/progetto/src/unique_table.cpp
@@ -4,8 +4,8 @@
  *
  * Implementa:
  *   • array globale `unique_table[]` (open addressing, size = UNIQUE_SIZE)
- *   • `unique_table_clear()`          – azzera lo storage
- *   • `unique_table_get_or_create()`  – lookup+insert su tripla (var,low,high)
+ *   • `unique_table_clear()`        – azzera lo storage
+ *   • `unique_get_or_create()`      – lookup+insert su tripla (var,low,high)
  *
  *  Al momento esiste solo la variante host; se in futuro servirà un backend
  *  device (CUDA) si potrà allocare una tabella analoga in memoria globale GPU
@@ -31,9 +31,9 @@ void unique_table_clear(void)
     std::memset(unique_table, 0, sizeof(unique_table));
 }
 
-OBDDNode* unique_table_get_or_create(int var,
-                                     OBDDNode* low,
-                                     OBDDNode* high)
+OBDDNode* unique_get_or_create(int var,
+                               OBDDNode* low,
+                               OBDDNode* high)
 {
     /* Regola di riduzione: se i due figli coincidono ⇒ ritorna direttamente */
     if (low == high) return low;


### PR DESCRIPTION
## Summary
- Correct the function name in the unique table implementation to match its header declaration
- Fix the per-thread cache macro guard in apply_cache so thread-local caching can be enabled

## Testing
- `make CUDA=0 OBJ_DIR=build_tmp BIN_DIR=bin_tmp run-seq`

------
https://chatgpt.com/codex/tasks/task_e_6895048f13948325b2e3c1bc69667fdc