### PR TITLE
Use OBDD_PER_THREAD_CACHE flag for thread cache

### DIFF
--- a/progetto/src/apply_cache.cpp
+++ b/progetto/src/apply_cache.cpp
@@ -25,7 +25,7 @@ struct KeyHash {
 };
 
 /* ---------- modalità GLOBAL vs THREAD_local --------------------*/
-#if defined(DOBDD_PER_THREAD_CACHE)
+#if defined(OBDD_PER_THREAD_CACHE)
 /* ---- 1) cache privata al thread --------------------------------*/
 static thread_local std::unordered_map<Key,OBDDNode*,KeyHash> tl_cache;
 
@@ -85,7 +85,7 @@ void apply_cache_global_merge() {}          /* no-op */
 /* helper per debug / test */
 void apply_cache_clear()
 {
-#if defined(DOBDD_PER_THREAD_CACHE)
+#if defined(OBDD_PER_THREAD_CACHE)
     tl_cache.clear();
 #else
     std::lock_guard<std::mutex> g(mtx);

--- a/progetto/src/obdd_openmp_optim.cpp
+++ b/progetto/src/obdd_openmp_optim.cpp
@@ -39,7 +39,7 @@ struct KeyHash {
 
 using LocalCache = std::unordered_map<Key, OBDDNode*, KeyHash>;
 
-#if defined(DOBDD_PER_THREAD_CACHE)
+#if defined(OBDD_PER_THREAD_CACHE)
 /* --- lista globale dei TLS per la merge -------------------------*/
 static std::vector<LocalCache*> g_tls;
 static std::mutex               g_tls_mtx;
@@ -123,7 +123,7 @@ OBDDNode* obdd_parallel_apply_omp_opt(const OBDD* A, const OBDD* B, OBDD_Op op)
 {
     const int CUT = 8;          /* K≈2^CUT nodi (empirico)          */
     LocalCache tls;
-#if defined(DOBDD_PER_THREAD_CACHE)
+#if defined(OBDD_PER_THREAD_CACHE)
     register_tls(tls);
 #endif
     OBDDNode* root=nullptr;
@@ -136,7 +136,7 @@ OBDDNode* obdd_parallel_apply_omp_opt(const OBDD* A, const OBDD* B, OBDD_Op op)
                          op,
                          CUT+2, CUT);
     }
-#if defined(DOBDD_PER_THREAD_CACHE)
+#if defined(OBDD_PER_THREAD_CACHE)
     merge_tls_into_master(tls);   /* 🔴 merge finale */
 #endif
     return root;


### PR DESCRIPTION
## Summary
- Switch thread cache guards from `DOBDD_PER_THREAD_CACHE` to `OBDD_PER_THREAD_CACHE`
- Ensure OpenMP backend and apply cache honor `-DOBDD_PER_THREAD_CACHE` flag

## Testing
- `make CXXFLAGS='-std=c++17 -O2 -Iinclude -Isrc -DOBDD_PER_THREAD_CACHE'`
- `make OMP=1 CXXFLAGS='-std=c++17 -O2 -Iinclude -Isrc -DOBDD_PER_THREAD_CACHE' build/obdd_openmp_optim.o`
- `./bin/test_seq`


------
https://chatgpt.com/codex/tasks/task_e_6895058aa33c8325bd7f9f71e221bead