### PR TITLE
Add CI workflow for CPU and OpenMP tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,43 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        compiler: [g++, clang++]
+    env:
+      CXX: ${{ matrix.compiler }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          if [ "${{ matrix.compiler }}" = "clang++" ]; then
+            sudo apt-get install -y clang libomp-dev
+          else
+            sudo apt-get install -y g++
+          fi
+
+      - name: Cache build
+        uses: actions/cache@v4
+        with:
+          path: |
+            progetto/build
+            progetto/bin
+          key: ${{ runner.os }}-${{ matrix.compiler }}-${{ hashFiles('progetto/**') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.compiler }}-
+
+      - name: Build and run CPU tests
+        working-directory: progetto
+        run: make run-seq
+
+      - name: Build and run OpenMP tests
+        working-directory: progetto
+        run: make OMP=1 run-omp


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to build project with g++ and clang++
- run sequential and OpenMP tests with cached build artifacts

## Testing
- `make run-seq`
- `make OMP=1 run-omp`


------
https://chatgpt.com/codex/tasks/task_e_689512a28efc8325843c3a6d3b0aa02d