### PR TITLE
Implement OBDD node tracking and cleanup

### DIFF
--- a/progetto/include/obdd.hpp
+++ b/progetto/include/obdd.hpp
@@ -108,6 +108,7 @@ OBDDNode   *obdd_parallel_apply_omp(const OBDD *bdd1,
    ===================================================== */
 int         is_leaf(const OBDDNode *node);
 OBDDNode   *apply_leaf(OBDD_Op op, int v1, int v2);
+size_t      obdd_nodes_tracked(void);
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/progetto/tests/test_apply.cpp
+++ b/progetto/tests/test_apply.cpp
@@ -16,38 +16,46 @@ TEST(ApplyBasic, AndOrNot)
     OBDD* bdd2 = obdd_create(10, order); /* x9 */
     bdd2->root = obdd_node_create(9, obdd_constant(0), obdd_constant(1));
 
-    OBDD tmp = {nullptr,10,order};
-
     /* (x0 AND x9) */
     OBDDNode* andRoot = obdd_apply(bdd1, bdd2, OBDD_AND);
     int assign[10] = {1,0,0,0,0,0,0,0,0,1};
-    tmp.root = andRoot;
-    int res = obdd_evaluate(&tmp, assign);
+    OBDD* tmp = obdd_create(10, order);
+    tmp->root = andRoot;
+    int res = obdd_evaluate(tmp, assign);
     ASSERT_EQ(res, 1);
+    obdd_destroy(tmp);
 
     /* OR su (1,1) = 1 */
     OBDDNode* orRoot = obdd_apply(bdd1, bdd2, OBDD_OR);
-    tmp.root = orRoot;
-    res = obdd_evaluate(&tmp, assign);
+    tmp = obdd_create(10, order);
+    tmp->root = orRoot;
+    res = obdd_evaluate(tmp, assign);
     ASSERT_EQ(res, 1);
+    obdd_destroy(tmp);
 
     /* XOR su (1,0) = 1 */
     assign[0] = 1;
     assign[9] = 0;
     OBDDNode* xorRoot = obdd_apply(bdd1, bdd2, OBDD_XOR);
-    tmp.root = xorRoot;
-    res = obdd_evaluate(&tmp, assign);
+    tmp = obdd_create(10, order);
+    tmp->root = xorRoot;
+    res = obdd_evaluate(tmp, assign);
     ASSERT_EQ(res, 1);
+    obdd_destroy(tmp);
     assign[9] = 1; /* ripristina x9 per i test successivi */
 
     /* NOT(x9) con x9=1 deve dare 0 */
     OBDDNode* notRoot = obdd_apply(bdd2, NULL, OBDD_NOT);
-    tmp.root = notRoot;
-    res = obdd_evaluate(&tmp, assign);
+    tmp = obdd_create(10, order);
+    tmp->root = notRoot;
+    res = obdd_evaluate(tmp, assign);
     ASSERT_EQ(res, 0);
+    obdd_destroy(tmp);
 
     obdd_destroy(bdd1);
     obdd_destroy(bdd2);
+
+    ASSERT_EQ(obdd_nodes_tracked(), 0u);
 }
 
 int main(int argc, char** argv)


### PR DESCRIPTION
## Summary
- track allocated OBDD nodes with a global set and count active BDDs
- traverse and free nodes in `obdd_destroy`
- add unit test ensuring node tracking reports no leaks

## Testing
- `make`
- `g++ -std=c++17 -Iinclude -Isrc tests/test_apply.cpp src/obdd_core.cpp src/apply_cache.cpp src/apply_cache_c_api.cpp src/unique_table.cpp -lgtest -pthread -o test_apply_exec`
- `./test_apply_exec`


------
https://chatgpt.com/codex/tasks/task_e_68951790b5948325a65b1ff07bba3eb2