### PR TITLE
Reduce CUDA BDDs via host-side obdd_reduce

### DIFF
--- a/progetto/include/obdd_cuda.hpp
+++ b/progetto/include/obdd_cuda.hpp
@@ -9,6 +9,8 @@
  * operatori logici binari/unari e un wrapper unico obdd_cuda_apply.
  *
  * Tutte le API sono disponibili solo se si compila con OBDD_ENABLE_CUDA.
+ * Ogni operazione logica restituisce una ROBDD ridotta copiando
+ * temporaneamente il risultato su host e invocando obdd_reduce().
  */
 
 #ifdef __cplusplus

--- a/progetto/tests/test_cuda.cpp
+++ b/progetto/tests/test_cuda.cpp
@@ -49,6 +49,17 @@ int main()
     obdd_cuda_or (dA, dB, &dOr );
     obdd_cuda_not(dB, &dNot);
 
+    // Verifica riduzione: x0 AND x0 => BDD di 3 nodi
+    void* dSelfAnd=nullptr; obdd_cuda_and(dA, dA, &dSelfAnd);
+    DeviceOBDD tmp{};
+    cudaMemcpy(&tmp, dSelfAnd, sizeof(DeviceOBDD), cudaMemcpyDeviceToHost);
+    assert(tmp.size == 3);
+
+    // x0 XOR x0 => costante 0, vettore di 2 nodi
+    void* dSelfXor=nullptr; obdd_cuda_xor(dA, dA, &dSelfXor);
+    cudaMemcpy(&tmp, dSelfXor, sizeof(DeviceOBDD), cudaMemcpyDeviceToHost);
+    assert(tmp.size == 2);
+
     int assign1[3] = {1,1,0};
     assert(eval_device_bdd(dAnd, assign1) == 1);
     assert(eval_device_bdd(dOr,  assign1) == 1);
@@ -66,6 +77,8 @@ int main()
       obdd_cuda_free_device(dAnd);
       obdd_cuda_free_device(dOr);
       obdd_cuda_free_device(dNot);
+      obdd_cuda_free_device(dSelfAnd);
+      obdd_cuda_free_device(dSelfXor);
     obdd_destroy(bddX0);
     obdd_destroy(bddX1);
 


### PR DESCRIPTION
## Summary
- ensure CUDA logical operations return canonical ROBDDs by copying results to host and invoking `obdd_reduce`
- document automatic reduction in CUDA API
- add CUDA test cases checking node-count reduction (x0 AND x0 and x0 XOR x0)

## Testing
- `make run-seq`
- `make CUDA=1 run-cuda` *(fails: nvcc: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68951dc3bb2c8325af4316f5d8bb63fa