### PR TITLE
Add final clause to OpenMP tasks to limit nested spawning

### DIFF
--- a/progetto/src/obdd_openmp.cpp
+++ b/progetto/src/obdd_openmp.cpp
@@ -55,10 +55,10 @@ static OBDDNode* obdd_parallel_apply_internal(const OBDDNode* n1,
 
     #pragma omp taskgroup
     {
-        #pragma omp task shared(lowRes)  firstprivate(n1_low, n2_low, op, depth) depend(out:lowRes) if(depth < OBDD_OMP_TASK_THRESHOLD)
+        #pragma omp task shared(lowRes)  firstprivate(n1_low, n2_low, op, depth) depend(out:lowRes) final(depth >= OBDD_OMP_TASK_THRESHOLD) if(depth < OBDD_OMP_TASK_THRESHOLD)
         lowRes  = obdd_parallel_apply_internal(n1_low,  n2_low,  op, depth + 1);
 
-        #pragma omp task shared(highRes) firstprivate(n1_high, n2_high, op, depth) depend(out:highRes) if(depth < OBDD_OMP_TASK_THRESHOLD)
+        #pragma omp task shared(highRes) firstprivate(n1_high, n2_high, op, depth) depend(out:highRes) final(depth >= OBDD_OMP_TASK_THRESHOLD) if(depth < OBDD_OMP_TASK_THRESHOLD)
         highRes = obdd_parallel_apply_internal(n1_high, n2_high, op, depth + 1);
     }
 


### PR DESCRIPTION
## Summary
- add `final(depth >= OBDD_OMP_TASK_THRESHOLD)` to OpenMP task directives in `obdd_parallel_apply_internal`
- retain existing `if(depth < OBDD_OMP_TASK_THRESHOLD)` guard for spawning tasks

## Testing
- `make OMP=1 run-omp`
- `make OMP=1 run-omp` with `#define OBDD_OMP_TASK_THRESHOLD 1`
- `make OMP=1 run-omp` with `#define OBDD_OMP_TASK_THRESHOLD 5`


------
https://chatgpt.com/codex/tasks/task_e_689f055c88408325a4121d755cfc3d63