### PR TITLE
Use shared unique table implementation in reduction

### DIFF
--- a/progetto/src/unique_table.cpp
+++ b/progetto/src/unique_table.cpp
@@ -5,7 +5,7 @@
  * Implementa:
  *   • array globale `unique_table[]` (open addressing, size = UNIQUE_SIZE)
  *   • `unique_table_clear()`        – azzera lo storage
- *   • `unique_get_or_create()`      – lookup+insert su tripla (var,low,high)
+ *   • `unique_table_get_or_create()` – lookup+insert su tripla (var,low,high)
  *
  *  Al momento esiste solo la variante host; se in futuro servirà un backend
  *  device (CUDA) si potrà allocare una tabella analoga in memoria globale GPU
@@ -31,9 +31,9 @@ void unique_table_clear(void)
     std::memset(unique_table, 0, sizeof(unique_table));
 }
 
-OBDDNode* unique_get_or_create(int var,
-                               OBDDNode* low,
-                               OBDDNode* high)
+OBDDNode* unique_table_get_or_create(int var,
+                                     OBDDNode* low,
+                                     OBDDNode* high)
 {
     /* Regola di riduzione: se i due figli coincidono ⇒ ritorna direttamente */
     if (low == high) return low;


### PR DESCRIPTION
## Summary
- Remove local unique table implementation from `obdd_core.cpp`
- Invoke `unique_table_clear` and `unique_table_get_or_create` for reductions
- Ensure build continues to include `unique_table.cpp`

## Testing
- `make run-seq`


------
https://chatgpt.com/codex/tasks/task_e_68a60fa73e708325a6d2eb99e3718900