### PR TITLE
Add reference counting to OBDD nodes

### DIFF
--- a/progetto/include/obdd.hpp
+++ b/progetto/include/obdd.hpp
@@ -41,6 +41,7 @@ typedef struct OBDDNode {
     int             varIndex;   /* indice della variabile, -1 leaf */
     struct OBDDNode *highChild; /* branch "1" */
     struct OBDDNode *lowChild;  /* branch "0" */
+    int             refCount;   /* reference count */
 } OBDDNode;
 
 /**

--- a/progetto/src/obdd_core.cpp
+++ b/progetto/src/obdd_core.cpp
@@ -59,14 +59,14 @@ static std::unordered_set<OBDDNode*> g_all_nodes;
 /* numero di BDD attivi, usato per sapere quando liberare le foglie */
 static int g_bdd_count = 0;
 
-static void free_nodes_rec(OBDDNode* node,
-                           std::unordered_set<OBDDNode*>& visited)
+static void free_nodes_rec(OBDDNode* node)
 {
-    if (!node || visited.count(node)) return;
-    if (node == g_falseLeaf || node == g_trueLeaf) return;
-    visited.insert(node);
-    free_nodes_rec(node->lowChild, visited);
-    free_nodes_rec(node->highChild, visited);
+    if (!node) return;
+    if (--node->refCount > 0) return;
+    if (node->varIndex >= 0) {
+        free_nodes_rec(node->lowChild);
+        free_nodes_rec(node->highChild);
+    }
     g_all_nodes.erase(node);
     std::free(node);
 }
@@ -93,15 +93,14 @@ void obdd_destroy(OBDD* bdd)
 {
     if (!bdd) return;
 
-    std::unordered_set<OBDDNode*> visited;
-    free_nodes_rec(bdd->root, visited);
+    free_nodes_rec(bdd->root);
 
     std::free(bdd->varOrder);
     std::free(bdd);
 
     if (--g_bdd_count == 0) {
-        if (g_falseLeaf) { g_all_nodes.erase(g_falseLeaf); std::free(g_falseLeaf); g_falseLeaf = nullptr; }
-        if (g_trueLeaf)  { g_all_nodes.erase(g_trueLeaf);  std::free(g_trueLeaf);  g_trueLeaf  = nullptr; }
+        if (g_falseLeaf) { free_nodes_rec(g_falseLeaf); g_falseLeaf = nullptr; }
+        if (g_trueLeaf)  { free_nodes_rec(g_trueLeaf);  g_trueLeaf  = nullptr; }
     }
 }
 
@@ -113,6 +112,7 @@ OBDDNode* obdd_constant(int value)
         g_falseLeaf->varIndex  = -1;
         g_falseLeaf->lowChild  = nullptr;
         g_falseLeaf->highChild = nullptr;
+        g_falseLeaf->refCount  = 1;
         g_all_nodes.insert(g_falseLeaf);
     }
     if (!g_trueLeaf) {
@@ -121,6 +121,7 @@ OBDDNode* obdd_constant(int value)
         /* puntatori qualunque != nullptr per riconoscere la foglia */
         g_trueLeaf->lowChild  = reinterpret_cast<OBDDNode*>(0x1);
         g_trueLeaf->highChild = reinterpret_cast<OBDDNode*>(0x1);
+        g_trueLeaf->refCount  = 1;
         g_all_nodes.insert(g_trueLeaf);
     }
     return value ? g_trueLeaf : g_falseLeaf;
@@ -132,6 +133,9 @@ OBDDNode* obdd_node_create(int varIndex, OBDDNode* low, OBDDNode* high)
     n->varIndex  = varIndex;
     n->lowChild  = low;
     n->highChild = high;
+    n->refCount  = 1;
+    if (low)  ++low->refCount;
+    if (high) ++high->refCount;
     g_all_nodes.insert(n);
     return n;
 }


### PR DESCRIPTION
## Summary
- Track OBDD node usage with a new `refCount` field
- Manage node lifetime via reference counting in creation and destruction routines

## Testing
- ❌ `make run-seq` *(fails: `obdd_nodes_tracked()` expected 0 but was 6)*

------
https://chatgpt.com/codex/tasks/task_e_68a60f8899b883259f801f2ce239969b