### PR TITLE
Protect node tracking with mutex

### DIFF
--- a/progetto/README.md
+++ b/progetto/README.md
@@ -5,6 +5,7 @@ This project implements an Ordered Binary Decision Diagram (OBDD) library with o
 ## Design choices
 
 * **Memory management** – all dynamically created nodes are tracked in a global set so that `obdd_destroy` can reclaim every allocation. Constant leaves are singletons and freed when the last BDD handle is destroyed.
+* **Thread safety** – node creation and destruction are guarded by a global mutex, making the API safe to use from multiple threads.
 * **C/C++ interface** – the public API is defined in `include/obdd.hpp` and exposed to pure C code through the lightweight wrapper `include/obdd.h`, avoiding extra wrapper layers.
 * **Automatic CUDA architecture** – `make` invokes `scripts/detect_gpu_arch.sh` to query `nvidia-smi` and pick the appropriate `-gencode` flag. This removes the need to manually edit `NVCCFLAGS` when compiling on different GPUs.
 


### PR DESCRIPTION
## Summary
- add a static `std::mutex` to guard global node structures
- use `std::lock_guard` in node create/destroy helpers
- document thread-safe node management in README

## Testing
- `make CUDA=0 run-seq` *(fails: fatal error: gtest/gtest.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a613aa11d48325868aeb746a9b4148